### PR TITLE
deps: migrate container images from Bitnami to Soldevelo equivalents

### DIFF
--- a/helm-charts/postgresql/values.yaml
+++ b/helm-charts/postgresql/values.yaml
@@ -1598,8 +1598,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r49
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -1707,8 +1707,8 @@ metrics:
   ##
   image:
     registry: docker.io
-    repository: bitnami/postgres-exporter
-    tag: 0.17.1-debian-12-r13
+    repository: soldevelo/postgres-exporter
+    tag: 0.17.1-debian-12-r0
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
## Dependency update: Bitnami to SolDevelo container images

Bitnami changed its container image distribution model on **August 28, 2025**, restricting access to many previously free images.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides free drop-in replacement images built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a maintained fork of `bitnami/containers`, published to Docker Hub under the `soldevelo/` namespace. Tags are kept in sync with upstream Bitnami.

This PR updates all affected image references in the repository.

## Changed images

- `bitnami/os-shell:12-debian-12-r49` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnami/postgres-exporter:0.17.1-debian-12-r13` → [`soldevelo/postgres-exporter:0.17.1-debian-12-r0`](https://hub.docker.com/r/soldevelo/postgres-exporter)